### PR TITLE
Refactor string concatenations to template strings

### DIFF
--- a/src/main/webapp/src/js/achievements.js
+++ b/src/main/webapp/src/js/achievements.js
@@ -2,17 +2,17 @@ Vue.component('achievement',{
     props: ['achievement'],
 
     template:
-        '<div class="card">\n' +
-        '  <div class="card-body" v-bind:class="{ \'bg-success\': achievement.state > 2}">\n' +
-        '    <h5 class="card-title"  v-if="achievement.state > 0">{{ achievement.name }}</h5>\n' +
-        '    <h5 class="card-title"  :title="localisation.unknownAchievementTooltip" ' +
-        '      v-else>{{localisation.unknownAchievement}}</h5>\n' +
-        '    <div  v-if="achievement.state > 1"class="card-text">\n' +
-        '      {{ achievement.desc }}\n' +
-        '    </div>' +
-        '    <div class="card-text" v-if="achievement.state > 2"> {{localisation.completed}}</div>' +
-        '  </div>\n' +
-        '</div>'
+        `<div class="card">
+            <div class="card-body" v-bind:class="{ \'bg-success\': achievement.state > 2}">
+            <h5 class="card-title"  v-if="achievement.state > 0">{{ achievement.name }}</h5>
+            <h5 class="card-title"  :title="localisation.unknownAchievementTooltip"       v-else>{{localisation.unknownAchievement}}</h5>
+            <div  v-if="achievement.state > 1" class="card-text">
+                {{ achievement.desc }}
+            </div>
+            <div class="card-text" v-if="achievement.state > 2">
+                {{localisation.completed}}</div>
+            </div>
+        </div>`
 
 })
 

--- a/src/main/webapp/src/js/alert.js
+++ b/src/main/webapp/src/js/alert.js
@@ -13,7 +13,8 @@ Vue.component('alert-box', {
             ]
         }
     },
-    template: '<div class="alert" v-bind:class="alertClasses[type]" role="alert">\n' +
-        '  {{alertMessage}}\n' +
-        '</div>'
+    template:
+        `<div class="alert" v-bind:class="alertClasses[type]" role="alert">
+            {{alertMessage}}\n
+        </div>`
 });

--- a/src/main/webapp/src/js/binarySelect.js
+++ b/src/main/webapp/src/js/binarySelect.js
@@ -46,12 +46,12 @@ Vue.component('BinarySelect', {
         this.nextRound();
     },
 
-    template: '<div class="row" :title="binarySelectHelp" v-bind:class="{\'disabled-div\': disabled}">\n' +
-        '                                <div class="col-sm" >\n' +
-        '                                        <feature-box v-bind:feature="feature1" v-on:toggled="toggled" v-on:useless-toggle="uselessToggle"></feature-box>\n' +
-        '                                </div>\n' +
-        '                                <div class="col-sm">\n' +
-        '                                        <feature-box v-bind:feature="feature2" v-on:toggled="toggled" v-on:useless-toggle="uselessToggle"></feature-box>\n' +
-        '                                </div>\n' +
-        '                        </div>'
-})
+    template:
+        `<div class="row" :title="binarySelectHelp" v-bind:class="{'disabled-div': disabled}">
+            <div class="col-sm">
+                <feature-box v-bind:feature="feature1" v-on:toggled="toggled" v-on:useless-toggle="uselessToggle"></feature-box>
+            </div>
+            <div class="col-sm">
+                <feature-box v-bind:feature="feature2" v-on:toggled="toggled" v-on:useless-toggle="uselessToggle"></feature-box>
+            </div>
+        </div>`})

--- a/src/main/webapp/src/js/featureDisplay.js
+++ b/src/main/webapp/src/js/featureDisplay.js
@@ -14,42 +14,40 @@ Vue.component('feature-box', {
             return this.feature.desc.replace(/(\\n)+/g, '<br>');
         }
     },
-    template: '                <div class="card feature-display" v-bind:class="{ \'bg-primary\': feature.toggled, \'gray-out\': feature.useless}" >' +
-        '                        <div class="card-body">' +
-        '                         <h5 class="card-title">{{ feature.name }}</h5>' +
-        '                         <p class="card-text" v-html="desc"></p>' +
-        '                        </div>' +
-        '                        <div class="btn-group">' +
-        '                        <button type="button" class="btn btn-secondary" data-toggle="modal" :data-target="\'#graphModal\' + feature.id" :disabled="feature.useless">' +
-        '                                {{ localisation.showGraphs }}' +
-        '                        </button>' +
-        '                        <button type="button" class="btn btn-primary" v-on:click="toggleMarked" :disabled="feature.useless">{{ localisation.selectFeature}}</button>' +
-        '                        <button type="button" class="btn btn-secondary" v-on:click="toggleUseless">{{ localisation.toggleUseless}}</button>' +
-        '                        </div>' +
-        '                        <div class="modal fade" :id="\'graphModal\' + feature.id" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">' +
-        '                                <div class="modal-dialog modal-lg" role="document">' +
-        '                                        <div class="modal-content">' +
-        '                                                <div class="modal-header">' +
-        '                                                        <button type="button" :title="localisation.close" class="close" data-dismiss="modal" aria-label="Close">' +
-        '                                                                <span aria-hidden="true">&times;</span>' +
-        '                                                        </button>' +
-        '                                                </div>' +
-        '                                                <div class="modal-body">' +
-        '                                                        <div class="container">' +
-        '                                                                <div class="row">' +
-        '                                                                        <div class="col-sm">' +
-        '                                                                                <img class="img-fluid" :src="feature.graph1"/>' +
-        '                                                                        </div>' +
-        '                                                                        <div class="col-sm">' +
-        '                                                                                <img class="img-fluid" :src="feature.graph2"/>' +
-        '                                                                        </div>' +
-        '                                                                </div>' +
-        '                                                        </div>' +
-        '                                                </div>' +
-        '                                        </div>' +
-        '                                </div>' +
-        '                        </div>' +
-        '                </div>',
+    template:
+        `<div class="card feature-display" v-bind:class="{ 'bg-primary': feature.toggled, 'gray-out': feature.useless}">
+            <div class="card-body"><h5 class="card-title">{{ feature.name }}</h5>
+                <p class="card-text" v-html="desc"></p></div>
+            <div class="btn-group">
+                <button type="button" class="btn btn-secondary" data-toggle="modal" :data-target="'#graphModal' + feature.id"
+                        :disabled="feature.useless"> {{ localisation.showGraphs }}
+                </button>
+                <button type="button" class="btn btn-primary" v-on:click="toggleMarked" :disabled="feature.useless">{{
+                    localisation.selectFeature}}
+                </button>
+                <button type="button" class="btn btn-secondary" v-on:click="toggleUseless">{{ localisation.toggleUseless}}
+                </button>
+            </div>
+            <div class="modal fade" :id="'graphModal' + feature.id" tabindex="-1" role="dialog"
+                 aria-labelledby="exampleModalLabel" aria-hidden="true">
+                <div class="modal-dialog modal-lg" role="document">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <button type="button" :title="localisation.close" class="close" data-dismiss="modal"
+                                    aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        </div>
+                        <div class="modal-body">
+                            <div class="container">
+                                <div class="row">
+                                    <div class="col-sm"><img class="img-fluid" :src="feature.graph1"/></div>
+                                    <div class="col-sm"><img class="img-fluid" :src="feature.graph2"/></div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>`,
     methods: {
         toggleMarked: function () {
             oldVal = this.feature.toggled;

--- a/src/main/webapp/src/js/gamecreation.js
+++ b/src/main/webapp/src/js/gamecreation.js
@@ -6,14 +6,15 @@ Vue.component('pattern-selection', {
             selectedPattern: {}
         }
     },
-    template: '<div class="input-group mb-3">\n' +
-        '  <div class="input-group-prepend">\n' +
-        '    <label class="input-group-text" >{{localisation.pattern}}</label>\n' +
-        '  </div>\n' +
-        '  <select class="custom-select" v-model="selectedPattern">\n' +
-        '    <option v-for="(p, index) in listOfPatterns" v-bind:key="index" :value="p">{{p.title}}</option>' +
-        '  </select>\n' +
-        '</div>',
+    template:
+        `<div class="input-group mb-3">
+            <div class="input-group-prepend">
+                <label class="input-group-text">{{localisation.pattern}}</label>
+            </div>
+            <select class="custom-select" v-model="selectedPattern">
+                <option v-for="(p, index) in listOfPatterns" v-bind:key="index" :value="p">{{p.title}}</option>
+            </select>
+        </div>`,
     mounted: function() {
         var self = this;
         axios({

--- a/src/main/webapp/src/js/gamemodesCreation.js
+++ b/src/main/webapp/src/js/gamemodesCreation.js
@@ -4,7 +4,7 @@
  */
 Vue.component('gamemode-config-binarySelect', {
     props: ['configString'],
-    template: '<div></div>',
+    template: `<div></div>`,
 
     mounted: function (newVal) {
         this.$emit('update-config-str', "binarySelect")
@@ -17,27 +17,26 @@ Vue.component('gamemode-config-matrixSelect', {
             conf: this.isValidConfig(this.configString)?this.configString:'matrixSelect,0,0,0'
         }
     },
-    template: '<div>\n' +
-        '  <div class="input-group mb-3">\n' +
-        '  <div class="input-group-prepend">\n' +
-        '    <span class="input-group-text" >{{localisation.numberOfFeatures}}</span>\n' +
-        '  </div>\n' +
-        '  <input type="number" min="0" class="form-control"  v-model="numberOfFeatures">' +
-        '</div>' +
-        '<div class="input-group mb-3">\n' +
-        '  <div class="input-group-prepend">\n' +
-        '    <span class="input-group-text">{{localisation.minNumberOfFeatures}}</span>\n' +
-        '  </div>\n' +
-        '  <input type="number" min="0" :max="max" class="form-control"  v-model="min">\n' +
-        '</div>\n' +
-        '<div class="input-group mb-3">\n' +
-        '  <div class="input-group-prepend">\n' +
-        '    <span class="input-group-text">{{localisation.maxNumberOfFeatures}}</span>\n' +
-        '  </div>\n' +
-        '  <input type="number" :min="min" :max="numberOfFeatures" class="form-control"  v-model="max">\n' +
-        '</div>\n' +
-        '</div>',
-
+    template:
+        `<div>
+            <div class="input-group mb-3">
+                <div class="input-group-prepend">
+                    <span class="input-group-text">{{localisation.numberOfFeatures}}</span>
+                </div>
+                <input type="number" min="0" class="form-control" v-model="numberOfFeatures">
+            </div>
+            <div class="input-group mb-3">
+                <div class="input-group-prepend">
+                    <span class="input-group-text">{{localisation.minNumberOfFeatures}}</span>
+                </div>
+                <input type="number" min="0" :max="max" class="form-control" v-model="min"></div>
+            <div class="input-group mb-3">
+                <div class="input-group-prepend">
+                    <span class="input-group-text">{{localisation.maxNumberOfFeatures}}</span>
+                </div>
+                <input type="number" :min="min" :max="numberOfFeatures" class="form-control" v-model="max">
+            </div>
+        </div>`,
     methods: {
         getArgByIndex: function (index) {
             var args = this.conf.split(',');
@@ -102,17 +101,20 @@ Vue.component('gamemode-config', {
         }
     },
     // language=HTML
-    template: '<div  class="input-group mb-3">' +
-        '<div class="input-group-prepend">\n' +
-        '    <span class="input-group-text">{{localisation.gamemode}}</span>\n' +
-        '  </div>' +
-        '<select class="custom-select" v-model="currentGm">' +
-        '<option v-for="(gm, index) in listOfGamemodes" v-bind:key="index"' +
-        '   v-bind:config-string="gamemodeConfigStr" :value="gm.value">{{gm.title}}</option>' +
-        '</select> ' +
-        '<component v-bind:is="componentName" v-bind:config-string="gamemodeConfigStr" v-on:update-config-str="updateConfString">' +
-        '</component>' +
-        '</div>',
+    template:
+        `<div class="input-group mb-3">
+            <div class="input-group-prepend">
+                <span class="input-group-text">{{localisation.gamemode}}</span>
+            </div>
+            <select class="custom-select" v-model="currentGm">
+                <option v-for="(gm, index) in listOfGamemodes" v-bind:key="index" v-bind:config-string="gamemodeConfigStr"
+                        :value="gm.value">{{gm.title}}
+                </option>
+            </select>
+            <component v-bind:is="componentName" v-bind:config-string="gamemodeConfigStr"
+                       v-on:update-config-str="updateConfString">
+            </component>
+        </div>`,
     computed: {
         componentName: function () {
             return 'gamemode-config-' + this.currentGm;

--- a/src/main/webapp/src/js/matrixSelect.js
+++ b/src/main/webapp/src/js/matrixSelect.js
@@ -1,10 +1,11 @@
 Vue.component('matrix-row', {
     props: ['feature-list'],
-    template: '<div class="mt-2 row" :title="localisation.matrixSelectHelp">\n' +
-        '            <feature-box  v-on:toggled="toggled" v-on:useless-toggle="uselessToggle" class="col p-0 mr-2" v-for="feature in featureList" ' +
-        '                           v-bind:key="feature.id"' +
-        '                           v-bind:feature="feature"></feature-box>' +
-        '        </div>',
+    template:
+        `<div class="mt-2 row" :title="localisation.matrixSelectHelp">
+            <feature-box v-on:toggled="toggled" v-on:useless-toggle="uselessToggle" class="col p-0 mr-2"
+                v-for="feature in featureList" v-bind:key="feature.id" v-bind:feature="feature">
+            </feature-box>
+        </div>`,
     methods: {
         toggled: function (newVal, oldVal) {
             this.$emit("toggled", newVal, oldVal)
@@ -36,11 +37,13 @@ Vue.component('MatrixSelect', {
             return Math.ceil(this.options.numberOfFeatures / this.col);
         }
     },
-    template: '        <div ref="matrix" id="matrixSelect">' +
-        '<matrix-row  v-on:toggled="toggled" v-on:useless-toggle="uselessToggle" v-for="i in [...Array(row).keys()]"\n' +
-        '                    v-bind:key="i"\n' +
-        '                    v-bind:feature-list="featureList.slice(i * col, (i+1) * col)">\n' +
-        '        </matrix-row></div>',
+    template:
+        `<div ref="matrix" id="matrixSelect">
+            <matrix-row v-on:toggled="toggled" v-on:useless-toggle="uselessToggle" v-for="i in [...Array(row).keys()]"
+                        v-bind:key="i"
+                        v-bind:feature-list="featureList.slice(i * col, (i+1) * col)">
+            </matrix-row>
+        </div>`,
     methods: {
         toggled: function(newVal, oldVal) {
             if (newVal && !oldVal) this.count++;

--- a/src/main/webapp/src/js/organiser.js
+++ b/src/main/webapp/src/js/organiser.js
@@ -7,41 +7,50 @@ Vue.component('active-games-display', {
         }
     }
     ,
-    template: '<div class="container">' +
-        '       <div class="container">' +
-        '           <div class="row">' +
-        '               <div class="col-md-6 col-sm-12 col-xs-12"><div>{{ game.title }}</div>' +
-        '                   <div>{{ game.type }}</div>' +
-        '                   <div>{{game.desc}}</div>' +
-        '               </div>' +
-        '               <div class="col">' +
-        '                   <input type="button" :title="localisation.terminateGameHelp" class="btn btn-secondary float-right btn-space"' +
-        '                        v-on:click="terminate(game.id)" :value="localisation.terminate">' +
-        '                   <input type="button" class="btn btn-primary float-right btn-space" :value="localisation.invite"' +
-        '                       data-toggle="modal" :title="localisation.invitePlayerHelp" :data-target="\'#inviteModal\' + game.id">' +
-        '               </div>' +
-        '            </div>' +
-        '       </div>' +
-                '<div class="modal fade" :id="\'inviteModal\' + game.id" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">\n' +
-                '  <div class="modal-dialog" role="document">\n' +
-                '    <div class="modal-content">\n' +
-                '      <div class="modal-header">\n' +
-                '        <h5 class="modal-title" id="modalLabel">{{ localisation.invite }}</h5>\n' +
-                '        <button :title="localisation.closeTooltip" type="button" class="close" data-dismiss="modal" aria-label="Close">\n' +
-                '          <span aria-hidden="true" >&times;</span>\n' +
-                '        </button>\n' +
-                '      </div>\n' +
-                '      <div class="modal-body">' +
-                '               ' +
-                '       <player-invite-box v-bind:invite-string="inviteString" v-on:update-invite-string="updateInviteString"></player-invite-box>' +
-        '               <button class="btn btn-primary" v-on:click="invitePlayers(game.id)">{{localisation.sendInvitations}}</button>' +
-                '      </div>\n' +
-                '      <div class="modal-footer">\n' +
-                '      </div>\n' +
-                '    </div>\n' +
-                '  </div>\n' +
-        '</div>' +
-        '      </div>',
+    template:
+        `<div class="container">
+            <div class="container">
+                <div class="row">
+                    <div class="col-md-6 col-sm-12 col-xs-12">
+                        <div>
+                            {{ game.title }}
+                        </div>
+                        <div>
+                            {{ game.type }}
+                        </div>
+                        <div>
+                            {{game.desc}}
+                        </div>
+                    </div>
+                    <div class="col">
+                        <input type="button" :title="localisation.terminateGameHelp" class="btn btn-secondary float-right btn-space"
+                            v-on:click="terminate(game.id)" :value="localisation.terminate">
+                        <input type="button" class="btn btn-primary float-right btn-space" :value="localisation.invite"
+                            data-toggle="modal" :title="localisation.invitePlayerHelp" :data-target="'#inviteModal' + game.id">
+                    </div>
+                </div>
+            </div>
+            <div class="modal fade" :id="'inviteModal' + game.id" tabindex="-1" role="dialog"
+                 aria-labelledby="exampleModalLabel" aria-hidden="true">
+                <div class="modal-dialog" role="document">
+                    <div class="modal-content">
+                        <div class="modal-header"><h5 class="modal-title" id="modalLabel">{{ localisation.invite }}</h5>
+                            <button :title="localisation.closeTooltip" type="button" class="close" data-dismiss="modal"
+                                    aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        </div>
+                        <div class="modal-body">
+                            <player-invite-box v-bind:invite-string="inviteString"
+                                               v-on:update-invite-string="updateInviteString">
+                            </player-invite-box>
+                            <button class="btn btn-primary" v-on:click="invitePlayers(game.id)">
+                                {{localisation.sendInvitations}}
+                            </button>
+                        </div>
+                        <div class="modal-footer"></div>
+                    </div>
+                </div>
+            </div>
+        </div>`,
     methods: {
         terminate: function(gameId) {
             axios({
@@ -75,18 +84,26 @@ Vue.component('active-games-display', {
 
 Vue.component('terminated-games-display', {
     props: ['game'],
-    template: '<div class="container">' +
-        '       <div class="container">' +
-        '           <div class="row">' +
-        '               <div class="col-md-6 col-sm-12 col-xs-12"><div>{{ game.title }}</div>' +
-        '                   <div>{{ game.type }}</div>' +
-        '               </div>' +
-        '               <div class="col">' +
-        '                   <input type="button" :title="localisation.deleteGameHelp" class="btn btn-secondary float-right btn-space" v-on:click="remove(game.id)" :value="localisation.del">' +
-        '               </div>' +
-        '            </div>' +
-        '       </div>' +
-        '      </div>',
+    template:
+        `<div class="container">
+            <div class="container">
+                <div class="row">
+                    <div class="col-md-6 col-sm-12 col-xs-12">
+                        <div>
+                            {{ game.title }}
+                        </div>
+                        <div>
+                            {{ game.type }}
+                        </div>
+                    </div>
+                    <div class="col">
+                        <input type="button" :title="localisation.deleteGameHelp"
+                                            class="btn btn-secondary float-right btn-space" v-on:click="remove(game.id)"
+                                            :value="localisation.del">
+                    </div>
+                </div>
+            </div>
+        </div>`,
     methods: {
         remove: function (gameId) {
             axios({
@@ -105,7 +122,7 @@ Vue.component('terminated-games-display', {
 
 Vue.component('stats-display', {
     props: [''],
-    template: ''
+    template: ``
 });
 
 var activeGames = new Vue({

--- a/src/main/webapp/src/js/player.js
+++ b/src/main/webapp/src/js/player.js
@@ -1,12 +1,21 @@
 Vue.component('game-display', {
     props: ['game'],
-    template: '<div class="card mt-1"><div class="card-body"><div class="row">' +
-        '                <div class="col"><div>{{ game.title }}</div>' +
-        '                <div>{{ game.type }}</div>' +
-        '                <div>{{ localisation.roundsPlayed + \': \' + game.roundsPlayed  }}</div>' +
-        '               <div>{{game.desc}}</div></div>' +
-        '                <div class="col"><input type="button" :title="localisation.playGameTooltip" class="btn btn-primary float-right" :value="localisation.play" v-on:click="startGame(game.id)"/></div>' +
-        '            </div></div></div>',
+    template:
+        `<div class="card mt-1">
+            <div class="card-body">
+                <div class="row">
+                    <div class="col">
+                        <div>{{ game.title }}</div>
+                        <div>{{ game.type }}</div>
+                        <div>{{ localisation.roundsPlayed + ': ' + game.roundsPlayed }}</div>
+                        <div>{{game.desc}}</div>
+                    </div>
+                    <div class="col"><input type="button" :title="localisation.playGameTooltip"
+                                            class="btn btn-primary float-right" :value="localisation.play"
+                                            v-on:click="startGame(game.id)"/></div>
+                </div>
+            </div>
+        </div>`,
     methods: {
         startGame: function(gameId) {
             localStorage.setItem("gameId", gameId);
@@ -18,51 +27,53 @@ Vue.component('game-display', {
 Vue.component('daily-challenge', {
     props:['daily'],
     template:
-        '<div class="card p-2" v-bind:class="{\'disabled-div\': daily.finished, \'bg-success\': daily.finished}">' +
-        '  <div class="card-body">' +
-        '    <h5 class="card-title">{{daily.title}}</h5>' +
-        '    <div class="card-text">' +
-        '     {{localisation.reward}}: {{daily.points}} {{localisation.points}}' +
-        '    </div>' +
-        '    <div class="card-text" v-if="daily.finished">' +
-        '       {{localisation.dailyFinished}}</div>' +
-        '  </div>' +
-        '</div>'
+        `<div class="card p-2" v-bind:class="{'disabled-div': daily.finished, 'bg-success': daily.finished}">
+            <div class="card-body"><h5 class="card-title">{{daily.title}}</h5>
+                <div class="card-text"> {{localisation.reward}}: {{daily.points}} {{localisation.points}}</div>
+                <div class="card-text" v-if="daily.finished"> {{localisation.dailyFinished}}</div>
+            </div>
+        </div>`
 })
-
 Vue.component('leaderboard-element', {
     props: ['place', 'username', 'points'],
-    template: '<tr>\n' +
-        '                    <th>{{ place }}</th>\n' +
-        '                    <th>{{ username }}</th>\n' +
-        '                    <th :title="localisation.lastWeekScoreTooltip">{{ points }}</th>\n' +
-        '                </tr>'
+    template:
+        `<tr>
+            <th>{{ place }}</th>
+            <th>{{ username }}</th>
+            <th :title="localisation.lastWeekScoreTooltip">{{ points }}</th>
+        </tr>`
 })
 
 Vue.component('stats-display', {
     props: ['points', 'username'],
-    template: '        <div>\n' +
-        '            <b class="text">{{username}}</b>\n' +
-        '            <p class="text" :title="localisation.totalScoreTooltip">{{points}}</p>\n' +
-        '        </div>'
+    template:
+        `<div>
+            <b class="text">{{username}}</b>
+            <p class="text" :title="localisation.totalScoreTooltip">{{points}}</p>
+        </div>`
 })
 Vue.component('invite-element', {
     props: ['title', 'gameId'],
-    template: '        <div class="card mt-1">\n' +
-        '            <div class="card-body">\n' +
-        '            <div class="row">\n' +
-        '                <div class="col">\n' +
-        '                <div class="float-left">{{title}}</div>\n' +
-        '                </div>\n' +
-        '                <div class="col">\n' +
-        '                <div class="btn-group" role="group" aria-label="Annehmen/Ablehnen von Einladungen">\n' +
-        '                    <button type="button" class="btn-primary btn float-right" v-on:click="accept(gameId)">{{localisation.accept}}</button>\n' +
-        '                    <button type="button" class="btn-secondary btn float-right" v-on:click="decline(gameId)">{{localisation.decline}}</button>\n' +
-        '                </div>\n' +
-        '                </div>\n' +
-        '            </div>\n' +
-        '            </div>\n' +
-        '        </div>',
+    template:
+        `<div class="card mt-1">
+            <div class="card-body">
+                <div class="row">
+                    <div class="col">
+                        <div class="float-left">{{title}}</div>
+                    </div>
+                    <div class="col">
+                        <div class="btn-group" role="group" aria-label="Annehmen/Ablehnen von Einladungen">
+                            <button type="button" class="btn-primary btn float-right" v-on:click="accept(gameId)">
+                                {{localisation.accept}}
+                            </button>
+                            <button type="button" class="btn-secondary btn float-right" v-on:click="decline(gameId)">
+                                {{localisation.decline}}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>`,
     methods: {
         accept: function (gameId) {
             axios({

--- a/src/main/webapp/src/js/playerInvite.js
+++ b/src/main/webapp/src/js/playerInvite.js
@@ -5,15 +5,15 @@ Vue.component('player-invite-single', {
         }
     },
 
-    template: '<div class="input-group mb-3">\n' +
-        '  <input type="email" class="form-control" placeholder="" aria-label="" ' +
-        '       v-model="email" aria-describedby="inviteButton">\n' +
-        '  <div class="input-group-append">\n' +
-        '    <button class="btn btn-outline-secondary" type="button" :disabled="!this.validateEmail"' +
-        ' v-on:click="newEmail" id="inviteButton">{{ localisation.invite }}</button>\n' +
-        '  </div>\n' +
-        '</div>',
-
+    template:
+        `<div class="input-group mb-3"><input type="email" class="form-control" placeholder="" aria-label="" v-model="email"
+                                             aria-describedby="inviteButton">
+            <div class="input-group-append">
+                <button class="btn btn-outline-secondary" type="button" :disabled="!this.validateEmail" v-on:click="newEmail"
+                        id="inviteButton">{{ localisation.invite }}
+                </button>
+            </div>
+        </div>`, 
     methods: {
         newEmail: function () {
             this.$emit('new-email', this.email)
@@ -34,9 +34,12 @@ Vue.component('player-invite-textarea', {
             rawText: this.inviteString
             }
         },
-    template: '<div class="input-group">\n' +
-        '  <textarea class="form-control" aria-label="" :title="localisation.gamecreationMassInviteTooltip" v-model="rawText"></textarea>\n' +
-        '</div>',
+    template:
+        `<div class="input-group">
+            <textarea class="form-control" aria-label=""
+                                           :title="localisation.gamecreationMassInviteTooltip" v-model="rawText">
+            </textarea>
+        </div>`,
     methods: {
         validateEmail: function (email) {
             var re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
@@ -72,10 +75,10 @@ Vue.component('player-invite-textarea', {
 });
 Vue.component('player-invite-nav-tab', {
     props: ['title', 'value', 'current-tab'],
-    template: '<li class="nav-item">\n' +
-        '                            <a class="nav-link" v-bind:class="{active: currentTab == value}"\n' +
-        '                                v-on:click="$emit(\'update-tab\', value)" href="#" v-on>{{title}}</a>\n' +
-        '                        </li>'
+    template:
+        `<li class="nav-item">
+            <a class="nav-link" v-bind:class="{active: currentTab == value}" v-on:click="$emit('update-tab', value)" href="#" v-on>{{title}}</a>
+        </li>`
 });
 Vue.component('player-invite-box', {
     props: ['invite-string'],
@@ -118,14 +121,14 @@ Vue.component('player-invite-box', {
             this.currentTab = value;
         }
     },
-    template: '<div>' +
-        '<ul class="nav nav-tabs">\n' +
-        '<player-invite-nav-tab v-for="(value, index) in playerInputType" v-bind:key="index"\n' +
-        '                       v-bind:title="value.title" v-bind:value="value.value"\n' +
-        '                       v-on:update-tab="updateTab">\n' +
-        '</player-invite-nav-tab>\n' +
-        '</ul>\n' +
-        '<component v-bind:is="currentTabComponent" v-on:new-email="addPlayer" v-bind:invite-string="inviteString"\n' +
-        '           v-on:update-invited="updateInviteString"></component>' +
-        '</div>'
+    template:
+        `<div>
+            <ul class="nav nav-tabs">
+                <player-invite-nav-tab v-for="(value, index) in playerInputType" v-bind:key="index" v-bind:title="value.title"
+                                       v-bind:value="value.value" v-on:update-tab="updateTab"></player-invite-nav-tab>
+            </ul>
+            <component v-bind:is="currentTabComponent" v-on:new-email="addPlayer" v-bind:invite-string="inviteString"
+                       v-on:update-invited="updateInviteString">
+            </component>
+        </div>`
 })

--- a/src/main/webapp/src/js/pointsDisplay.js
+++ b/src/main/webapp/src/js/pointsDisplay.js
@@ -1,9 +1,11 @@
 Vue.component('points-display', {
     props: ['points'],
-    template: '<div v-if="points !== undefined" class="card" style="width: 18rem;">\n' +
-        '  <div class="card-body">\n' +
-        '    <h5 class="card-title">{{localisation.points}}</h5>' +
-        '       <div class="card-text">{{points}}</div>' +
-        '  </div>\n' +
-        '</div>'
+    template:
+        `<div v-if="points !== undefined" class="card" style="width: 18rem;">
+            <div class="card-body"><h5 class="card-title">{{localisation.points}}</h5>
+                <div class="card-text">
+                    {{points}}
+                </div>
+            </div>
+        </div>`
 })

--- a/src/main/webapp/src/js/streak.js
+++ b/src/main/webapp/src/js/streak.js
@@ -19,16 +19,17 @@ Vue.component('streak-display', {
         }
     },
     template:
-        '<div class="card">' +
-        '    <div class="card-body">' +
-        '        <h5 class="card-title">{{ localisation.streak }}</h5>' +
-        '        <div class="card-text">\n' +
-        '            <div class="progress">\n' +
-        '                <div class="progress-bar bg-primary" role="progressbar" v-bind:style="{width: progress1}" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>\n' +
-        '                <div class="progress-bar bg-success" role="progressbar" v-bind:style="{width: progress2}" aria-valuenow="30" aria-valuemin="0" aria-valuemax="100"></div>\n' +
-        '            </div>' +
-        '            <div>{{this.streakText}}</div>\n' +
-        '        </div>\n' +
-        '    </div>\n' +
-        '</div>'
+        `<div class="card">
+            <div class="card-body"><h5 class="card-title">{{ localisation.streak }}</h5>
+                <div class="card-text">
+                    <div class="progress">
+                        <div class="progress-bar bg-primary" role="progressbar" v-bind:style="{width: progress1}"
+                             aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>
+                        <div class="progress-bar bg-success" role="progressbar" v-bind:style="{width: progress2}"
+                             aria-valuenow="30" aria-valuemin="0" aria-valuemax="100"></div>
+                    </div>
+                    <div>{{this.streakText}}</div>
+                </div>
+            </div>
+        </div>`
 })

--- a/src/main/webapp/src/js/terminationCreation.js
+++ b/src/main/webapp/src/js/terminationCreation.js
@@ -5,17 +5,20 @@ Vue.component('termination-config', {
             listOfTerminations: []
         }
     },
-    template: "<div class=\"input-group mb-3\">" +
-        "      <div class=\"input-group-prepend\">\n" +
-        "    <span class=\"input-group-text\" >{{localisation.termination}}</span>\n" +
-        "  </div>     " +
-        "<select class='custom-select' v-model='currentTermination' >\n" +
-        "    <option v-for='(term,index) in listOfTerminations' v-bind:key='index'" +
-        "               :value='term.value'>{{term.title}}</option>\n" +
-        "  </select>" +
-        "   <component v-bind:is='componentName' v-bind:termination-config-str='terminationConfigStr'" +
-        "               v-on:update-termination='updateTermination' v-bind:list-of-possible-terminations='listOfTerminations.slice(2,4)'></component>" +
-        "</div>",
+    template:
+        `<div class="input-group mb-3">
+            <div class="input-group-prepend">
+                <span class="input-group-text">{{localisation.termination}}</span>
+            </div>
+            <select class='custom-select' v-model='currentTermination'>
+                <option v-for='(term,index) in listOfTerminations' v-bind:key='index' :value='term.value'>{{term.title}}
+                </option>
+            </select>
+            <component v-bind:is='componentName' v-bind:termination-config-str='terminationConfigStr'
+                       v-on:update-termination='updateTermination'
+                       v-bind:list-of-possible-terminations='listOfTerminations.slice(2,4)'>
+            </component>
+        </div>`,
     methods: {
         updateTermination: function (newVal) {
             this.$emit('update-termination-str', newVal);
@@ -56,7 +59,8 @@ Vue.component('termination-config', {
     }
 });
 Vue.component('termination-config-organiser', {
-    template: '<div>{{localisation.organiserTerminationInfo}}</div>'
+    template:
+        `<div>{{localisation.organiserTerminationInfo}}</div>`
 })
 Vue.component('termination-config-composite', {
     props: ['list-of-possible-terminations', 'termination-config-str'],
@@ -116,29 +120,32 @@ Vue.component('termination-config-composite', {
         }
     },
 
-    template: '<div>' +
-        '     <div class="input-group mb-3" :title="localisation.selectTerminationTooltip">\n' +
-        '  <select class="custom-select" v-model="currentTermination">\n' +
-        '    <option v-for="(termination, index) in listOfPossibleTerminations" v-bind:key="index"' +
-        '               :value="termination" >{{termination.title}}</option>' +
-        '  </select>\n' +
-        ' <div class="input-group-append">\n' +
-        '    <button class="btn btn-outline-secondary" type="button" v-on:click="addTermination(currentTermination)">{{localisation.add}}</button>\n' +
-        '  </div>' +
-        '</div>' +
-        '<div v-for="(term, index) in terminations" class="row" >' +
-        '<div class="col-10">' +
-        '<component  v-bind:key="index" ' +
-        '           v-bind:is="\'termination-config-\' + term.value" v-bind:termination-config-str="terminationStrings[index]"' +
-        '           v-on:update-termination="addTerminationStringByIndex($event, index)"></component></div>' +
-        '<div class="col-2"> ' +
-        '<button type="button" class="close" v-on:click="removeTerminationByIndex(index)">\n' +
-        '          <span aria-hidden="true">&times;</span>\n' +
-        '        </button>\n' +
-        '</div>' +
-        '</div>' +
-        '</div>'
-
+    template:
+        `<div>
+            <div class="input-group mb-3" :title="localisation.selectTerminationTooltip"><select class="custom-select"
+                                                                                                 v-model="currentTermination">
+                <option v-for="(termination, index) in listOfPossibleTerminations" v-bind:key="index" :value="termination">
+                    {{termination.title}}
+                </option>
+            </select>
+                <div class="input-group-append">
+                    <button class="btn btn-outline-secondary" type="button" v-on:click="addTermination(currentTermination)">
+                        {{localisation.add}}
+                    </button>
+                </div>
+            </div>
+            <div v-for="(term, index) in terminations" class="row">
+                <div class="col-10">
+                    <component v-bind:key="index" v-bind:is="'termination-config-' + term.value"
+                               v-bind:termination-config-str="terminationStrings[index]"
+                               v-on:update-termination="addTerminationStringByIndex($event, index)"></component>
+                </div>
+                <div class="col-2">
+                    <button type="button" class="close" v-on:click="removeTerminationByIndex(index)"><span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+            </div>
+        </div>` 
 })
 
 Vue.component('termination-config-rounds', {
@@ -169,13 +176,13 @@ Vue.component('termination-config-rounds', {
             }
         }
     },
-    template: '<div class="input-group mb-3">\n' +
-        '  <div class="input-group-prepend">\n' +
-        '    <span class="input-group-text">{{localisation.rounds}}</span>\n' +
-        '  </div>\n' +
-        '  <input type="number" min="0" class="form-control" v-model="number">\n' +
-        '</div>'
-
+    template:
+        `<div class="input-group mb-3">
+            <div class="input-group-prepend">
+                <span class="input-group-text">{{localisation.rounds}}</span>
+            </div>
+            <input type="number" min="0" class="form-control" v-model="number">
+        </div>`
 });
 
 Vue.component('termination-config-time', {
@@ -212,11 +219,11 @@ Vue.component('termination-config-time', {
             }
         }
     },
-    template: '<div class="input-group mb-3">\n' +
-        '  <div class="input-group-prepend">\n' +
-        '    <span class="input-group-text" >{{localisation.endDate}}</span>\n' +
-        '  </div>\n' +
-        '  <date-picker v-bind:config="{format: \'DD/MM/YYYY HH:mm\'}" v-model="date"></date-picker>' +
-        '</div>'
-
+    template:
+        `<div class="input-group mb-3">
+            <div class="input-group-prepend">
+                <span class="input-group-text">{{localisation.endDate}}</span>
+            </div>
+            <date-picker v-bind:config="{format: 'DD/MM/YYYY HH:mm'}" v-model="date"></date-picker>
+        </div>`
 });


### PR DESCRIPTION
As creating vue html templates needed tremendous amounts of string concatenations, I changed the templates from using `''` strings to ` `` ` template strings which allow line breaks inside the string without the need for concatenating each line manually

Compatibility:
![image](https://user-images.githubusercontent.com/34923333/53099346-e8f5dd80-3525-11e9-9391-cf48e2064e8b.png)

