### PR TITLE
Use concurrent map implementations in the database

### DIFF
--- a/src/main/java/com/csselect/database/mysql/MysqlDatabaseAdapter.java
+++ b/src/main/java/com/csselect/database/mysql/MysqlDatabaseAdapter.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /**
@@ -46,13 +47,13 @@ public class MysqlDatabaseAdapter implements DatabaseAdapter {
      * @param configuration configuration to use
      */
     public MysqlDatabaseAdapter(Configuration configuration) {
-        gameMap = new HashMap<>();
-        gameAdapterMap = new HashMap<>();
+        gameMap = new ConcurrentHashMap<>();
+        gameAdapterMap = new ConcurrentHashMap<>();
         this.hostname = configuration.getDatabaseHostname();
         this.port = configuration.getDatabasePort();
         this.username = configuration.getDatabaseUsername();
         this.password = configuration.getDatabasePassword();
-        this.dataSources = new HashMap<>();
+        this.dataSources = new ConcurrentHashMap<>();
         this.dataSources.put(PRODUCT_DATABASE_NAME, createDataSource(PRODUCT_DATABASE_NAME));
         try {
             executeMysqlUpdate(Query.CREATE_PLAYER_TABLE);

--- a/src/main/java/com/csselect/database/mysql/MysqlPlayerAdapter.java
+++ b/src/main/java/com/csselect/database/mysql/MysqlPlayerAdapter.java
@@ -9,9 +9,9 @@ import org.pmw.tinylog.Logger;
 
 import java.sql.SQLException;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /**
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
  */
 public class MysqlPlayerAdapter extends MysqlUserAdapter implements PlayerAdapter {
 
-    private static final Map<PlayerAdapter, PlayerStats> PLAYERSTATS_MAP = new HashMap<>();
+    private static final Map<PlayerAdapter, PlayerStats> PLAYERSTATS_MAP = new ConcurrentHashMap<>();
 
     private static final MysqlDatabaseAdapter DATABASE_ADAPTER
             = (MysqlDatabaseAdapter) Injector.getInstance().getDatabaseAdapter();


### PR DESCRIPTION
Changed the maps that might get accessed by multiple threads simultaneously to concurrent implementations. As I can't reproduce the error on my machine, I would ask you to test whether the error still occurs

close #195 